### PR TITLE
Fix excess space below About section (mobile only)

### DIFF
--- a/components/HomeDeLayout.tsx
+++ b/components/HomeDeLayout.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import DeShellScrollRestore from '@/components/DeShellScrollRestore'
+import HomeDeMainContent from '@/components/HomeDeMainContent'
 import HomeDeSidebar from '@/components/HomeDeSidebar'
 import MobileSectionHeadingChrome from '@/components/MobileSectionHeadingChrome'
 import PortfolioChat from '@/components/PortfolioChat'
@@ -16,9 +17,7 @@ export default function HomeDeLayout({ children }: { children: React.ReactNode }
       <main className="home-de-main">
         <HomeDeSidebar />
 
-        <div className="home-de-main-content">
-          {children}
-        </div>
+        <HomeDeMainContent>{children}</HomeDeMainContent>
 
         <div className={`home-de-chat-panel${showChat ? ' home-de-chat-panel--open' : ''}`}>
           <div className="home-de-chat-panel-inner">

--- a/components/HomeDeMainContent.tsx
+++ b/components/HomeDeMainContent.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { useEffect, useState, type ReactNode } from 'react'
+import { usePathname } from 'next/navigation'
+import { getPinnedPortfolioSection } from '@/lib/deScroll'
+
+function isSinglePagePortfolio(pathname: string | null) {
+  const path = pathname?.endsWith('/') && pathname.length > 1 ? pathname.slice(0, -1) : pathname ?? ''
+  return path === '' || path === '/' || path === '/playground' || path === '/workshops'
+}
+
+/** Main scroll column — trims bottom padding on mobile once About is the pinned section. */
+export default function HomeDeMainContent({ children }: { children: ReactNode }) {
+  const pathname = usePathname()
+  const onPortfolio = isSinglePagePortfolio(pathname)
+  const [atSectionEnd, setAtSectionEnd] = useState(false)
+
+  useEffect(() => {
+    if (!onPortfolio) {
+      setAtSectionEnd(false)
+      return
+    }
+
+    let raf = 0
+    const sync = () => {
+      cancelAnimationFrame(raf)
+      raf = requestAnimationFrame(() => {
+        setAtSectionEnd(getPinnedPortfolioSection() === 'about')
+      })
+    }
+
+    sync()
+    window.addEventListener('scroll', sync, { passive: true })
+    document.addEventListener('scroll', sync, { passive: true, capture: true })
+    window.addEventListener('resize', sync, { passive: true })
+
+    return () => {
+      cancelAnimationFrame(raf)
+      window.removeEventListener('scroll', sync)
+      document.removeEventListener('scroll', sync, { capture: true })
+      window.removeEventListener('resize', sync)
+    }
+  }, [onPortfolio, pathname])
+
+  return (
+    <div
+      className={`home-de-main-content${atSectionEnd ? ' home-de-main-content--at-section-end' : ''}`}
+    >
+      {children}
+    </div>
+  )
+}

--- a/styles.css
+++ b/styles.css
@@ -609,7 +609,8 @@ body {
 .home-de-main-content {
   flex: 1;
   min-width: 0;
-  padding: calc(var(--de-gutter) + 0.5rem) var(--de-gutter) var(--sp-48);
+  padding: calc(var(--de-gutter) + 0.5rem) var(--de-gutter)
+    calc(var(--sp-80) + var(--sp-48));
   overflow-x: clip;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -617,8 +617,13 @@ body {
 @media (max-width: 768px) {
   .home-de-main-content {
     padding: var(--sp-24) var(--de-gutter-mobile)
-      calc(var(--sp-24) + var(--sp-32) + env(safe-area-inset-bottom, 0px));
+      calc(var(--sp-24) + var(--sp-48) + env(safe-area-inset-bottom, 0px));
     overflow: visible;
+  }
+
+  /* About is last — bottom section chrome hides; drop the extra scroll clearance. */
+  .home-de-main-content.home-de-main-content--at-section-end {
+    padding-bottom: calc(var(--sp-24) + env(safe-area-inset-bottom, 0px));
   }
 
   .home-de-portfolio-section + .home-de-portfolio-section {

--- a/styles.css
+++ b/styles.css
@@ -609,15 +609,14 @@ body {
 .home-de-main-content {
   flex: 1;
   min-width: 0;
-  padding: calc(var(--de-gutter) + 0.5rem) var(--de-gutter)
-    calc(var(--sp-80) + var(--sp-48));
+  padding: calc(var(--de-gutter) + 0.5rem) var(--de-gutter) var(--sp-48);
   overflow-x: clip;
 }
 
 @media (max-width: 768px) {
   .home-de-main-content {
     padding: var(--sp-24) var(--de-gutter-mobile)
-      calc(var(--sp-24) + 3.5rem + env(safe-area-inset-bottom, 0px));
+      calc(var(--sp-24) + var(--sp-32) + env(safe-area-inset-bottom, 0px));
     overflow: visible;
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes excess empty space below the **About** section on **mobile only**.

The previous approach (reducing bottom padding by ~24px globally on mobile) was too weak and did not address the root cause.

## Root cause

In the recent mobile nav update (`447ca1b`), bottom padding on `.home-de-main-content` was increased to `24px + 3.5rem` to clear the new **fixed bottom section chrome** while scrolling through earlier sections.

When the user reaches **About** (the last section), that bottom chrome **hides** — but the extra clearance padding remained, leaving a visible dead zone below About.

## Fix

- Keep the extra bottom clearance (`--sp-48`) while scrolling through Timeline → Workshops → Interactions → Writing
- Once About is the pinned section, toggle `home-de-main-content--at-section-end` and reduce bottom padding to `24px + safe-area` only
- **Desktop unchanged**

## Test plan

- [ ] Mobile: scroll to About — gap below email/availability line should be minimal
- [ ] Mobile: scroll through Writing/Interactions — last cards should still clear the bottom section chrome
- [ ] Desktop: no change to bottom spacing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2d48-b30c-740a-b6b7-5a411c076852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2d48-b30c-740a-b6b7-5a411c076852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

